### PR TITLE
[fixed] dependabot settings

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.1
+FROM python:3.8.12
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Asia/Tokyo

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,6 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: "python"
-        versions: ["~>3.9.0"]
+        versions: [">=3.9.0"]
     reviewers:
       - "yamap55"


### PR DESCRIPTION
dependabotのバージョン指定が正しくないため、Pythonのバージョンが上がってしまっている。
そのため、上がってしまったバージョンと、dependabotの設定を修正する。